### PR TITLE
Remove tests on Python 3.9

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
because the whole runtime is already running in Python 3.10, and we control this ourselves, it doesn't make sense to waste action minutes in testing something we are not going to use
