### PR TITLE
Use a custom paginator that returns the number of pages and the current page and does not use the links

### DIFF
--- a/proxylist/pagination.py
+++ b/proxylist/pagination.py
@@ -1,0 +1,12 @@
+from rest_framework import pagination
+from rest_framework.response import Response
+
+
+class ProxiesPagination(pagination.PageNumberPagination):
+    def get_paginated_response(self, data):
+        return Response({
+            'count': self.page.paginator.count,
+            'total_pages': self.page.paginator.num_pages,
+            'current_page': self.page.number,
+            'results': data
+        })

--- a/shadowmere/settings.py
+++ b/shadowmere/settings.py
@@ -240,7 +240,7 @@ AdminSite.site_header = "Shadowmere administration"
 PROMETHEUS_METRICS_EXPORT_PORT_RANGE = range(8002, 8008)
 
 REST_FRAMEWORK = {
-    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "DEFAULT_PAGINATION_CLASS": "proxylist.pagination.ProxiesPagination",
     "PAGE_SIZE": 10,
 }
 


### PR DESCRIPTION
it should be simpler for the frontend application to use this information.
The result looks like this:
![image](https://user-images.githubusercontent.com/5427672/198694870-4e8e55cc-5eb8-4996-aafb-3e4d61f79740.png)
instead of the original 
![image](https://user-images.githubusercontent.com/5427672/198694983-5c67e4cd-8803-49cc-974c-cce041fb158d.png)


