### PR TITLE
Add subscription compatible with v2ray and nekoray

### DIFF
--- a/proxylist/tests/test_subscription.py
+++ b/proxylist/tests/test_subscription.py
@@ -1,8 +1,11 @@
+import base64
 import json
 
 import flag
 from django.urls import reverse
 from rest_framework.test import APITestCase
+
+from proxylist.base64_decoder import decode_base64
 
 
 class SubEndpointTests(APITestCase):
@@ -44,3 +47,9 @@ class SubEndpointTests(APITestCase):
                 },
             ],
         )
+
+    def test_get_b64sub(self):
+        response = self.client.get(reverse("b64sub-list"))
+        self.assertEqual(response.status_code, 200)
+        content = decode_base64(response.content).decode("utf-8")
+        assert content == '\nss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpwcG15SVVQMmV1WU0@37.218.242.73:8091/#🇳🇱 Waalwijk, NB, Netherlands\nss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpHIXlCd1BXSDNWYW8@196.196.156.122:807#🇸🇪 Stockholm, AB, Sweden\nss://YWVzLTI1Ni1nY206ZmFCQW9ENTRrODdVSkc3@169.197.142.39:2375#🇺🇸 unknown'

--- a/proxylist/views.py
+++ b/proxylist/views.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import re
 
@@ -182,3 +183,17 @@ class SubViewSet(viewsets.ViewSet):
             )
         ]
         return Response(servers)
+
+
+class Base64SubViewSet(viewsets.ViewSet):
+    """
+    Subscription endpoint for the v2ray and nekoray apps
+    """
+
+    @method_decorator(cache_page(20 * 60))
+    def list(self, request, format=None):
+        server_list = ""
+        for proxy in Proxy.objects.filter(is_active=True).order_by("location_country_code"):
+            server_list += f"\n{proxy.url}#{flag.flag(proxy.location_country_code)} {proxy.location}"
+        b64_servers = base64.b64encode(server_list.encode("utf-8"))
+        return HttpResponse(b64_servers)

--- a/shadowmere/urls.py
+++ b/shadowmere/urls.py
@@ -10,6 +10,7 @@ router.register(r"proxies", views.ProxyViewSet)
 router.register(r"country-codes", views.CountryCodeViewSet, basename="country-codes")
 router.register(r"ports", views.PortViewSet, basename="ports")
 router.register(r"sub", views.SubViewSet, basename="sub")
+router.register(r"b64sub", views.Base64SubViewSet, basename="b64sub")
 
 urlpatterns = [
     path("admin/", admin.site.urls),


### PR DESCRIPTION
solves https://github.com/jadolg/shadowmere/issues/115

These applications don't use the regular subscription, instead, they feed on a base64 encoded list of proxy addresses.
This PR adds this new subscription format under `/api/b64sub/`