### PR TITLE
Change log level when a proxy can't be added from subscription

### DIFF
--- a/proxylist/tasks.py
+++ b/proxylist/tasks.py
@@ -91,7 +91,7 @@ def save_proxies(proxies_lists):
                 try:
                     proxy.save()
                 except Exception as e:
-                    logging.error(f"Failed to save proxy {proxy}, {e}")
+                    logging.warning(f"Failed to save proxy {proxy}, {e}")
 
 
 def process_line(line, all_urls):


### PR DESCRIPTION
sometimes it's just a duplicate we don't catch in the beginning and we don't need this on sentry