### PR TITLE
Capture exception when we can't decode a list.

### DIFF
--- a/proxylist/tasks.py
+++ b/proxylist/tasks.py
@@ -70,11 +70,14 @@ def poll_subscriptions(self):
                     )
                 if subscription.alive is False:
                     subscription.alive = True
-                    subscription.save()
             except requests.exceptions.ConnectionError as e:
                 logging.error(f"Failed to get subscription {subscription.url}, {e}")
                 subscription.alive = False
-                subscription.save()
+            except AttributeError as e:
+                logging.error(f"Error decoding subscription {subscription.url}, {e}")
+                subscription.alive = False
+
+            subscription.save()
 
     save_proxies(proxies_lists)
 


### PR DESCRIPTION
it's just flooding sentry and the only thing we can do (marking the list as broken) is already taken care of
