### PR TITLE
Decrease the log level when subscriptions fail to warning

### DIFF
--- a/proxylist/tasks.py
+++ b/proxylist/tasks.py
@@ -84,10 +84,10 @@ def poll_subscriptions(self):
                 requests.exceptions.ConnectionError,
                 requests.exceptions.SSLError,
             ) as e:
-                logging.error(f"Failed to get subscription {subscription.url}, {e}")
+                logging.warning(f"Failed to get subscription {subscription.url}, {e}")
                 subscription.alive = False
             except AttributeError as e:
-                logging.error(f"Error decoding subscription {subscription.url}, {e}")
+                logging.warning(f"Error decoding subscription {subscription.url}, {e}")
                 subscription.alive = False
 
             subscription.save()


### PR DESCRIPTION
we don't need a sentry notification every time subscriptions fail. If anything happen the subscription is marked as broken and that's good enough.
