### PR TITLE
Replace country code with country name in the list of flags in the old interface

### DIFF
--- a/proxylist/views.py
+++ b/proxylist/views.py
@@ -27,7 +27,7 @@ def list_proxies(request):
     country_codes = (
         Proxy.objects.filter(is_active=True)
         .order_by("location_country_code")
-        .values("location_country_code")
+        .values("location_country_code", "location_country")
         .distinct()
     )
     if location_country_code != "":

--- a/templates/index.html
+++ b/templates/index.html
@@ -59,7 +59,7 @@
                 Android</p>
             {% endblocktranslate %}
         <p><b>{% translate "Online:" %}</b> {{ proxy_list|length }} {% if location_country_code != "" %}
-            <img class="w3-margin" title="{{ country_code.location_country_code }}" width="70px" height="30px"
+            <img class="w3-margin" title="" width="70px" height="30px"
                  alt="Country flag for {{ location_country_code }}"
                  src="https://cdn.jsdelivr.net/npm/country-flag-emoji-json@2.0.0/dist/images/{{ location_country_code }}.svg">
         {% endif %}</p>
@@ -74,8 +74,8 @@
         {% for country_code in country_codes %}
             {% if country_code.location_country_code != "" %}
                 <a class="w3-button" href="/?location_country_code={{ country_code.location_country_code }}">
-                    <img title="{{ country_code.location_country_code }}" width="45px" height="35px"
-                         alt="Country flag for {{ country_code.location_country_code }}"
+                    <img title="{{ country_code.location_country }}" width="45px" height="35px"
+                         alt="Country flag for {{ country_code.location_country }}"
                          src="https://cdn.jsdelivr.net/npm/country-flag-emoji-json@2.0.0/dist/images/{{ country_code.location_country_code }}.svg">
                 </a>
             {% endif %}


### PR DESCRIPTION
this makes the hint when hovering show a readable indication of which country the flag belongs to instead of just the country code which might be as difficult as the flag itself
