### PR TITLE
Allow multiple shadowtest servers

### DIFF
--- a/proxylist/proxy.py
+++ b/proxylist/proxy.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import time
+from itertools import cycle
 
 import requests
 from django.core.cache import cache
@@ -9,10 +10,11 @@ from requests import ReadTimeout
 from requests.exceptions import InvalidJSONError, SSLError
 from urllib3.exceptions import MaxRetryError
 
-from shadowmere import settings
-from shadowmere.settings import CACHE_LOCATION_SECONDS
+from shadowmere.settings import CACHE_LOCATION_SECONDS, SHADOWTEST_SERVERS
 
 log = logging.getLogger("django")
+
+shadowtest_iterator = cycle(SHADOWTEST_SERVERS)
 
 
 class ShadowtestError(Exception):
@@ -38,7 +40,8 @@ def get_proxy_location(proxy_url):
         errored = False
         r = None
         try:
-            r = requests.post(settings.SHADOWTEST_URL, data={"address": proxy_url})
+            shadowtest_url = next(shadowtest_iterator)
+            r = requests.post(shadowtest_url, data={"address": proxy_url})
         except (SSLError, ReadTimeout, MaxRetryError) as e:
             log.error(
                 f"Error connecting to Shadowtest: {e}",

--- a/shadowmere/settings.py
+++ b/shadowmere/settings.py
@@ -29,7 +29,9 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv("DEBUG", False)
 
-SHADOWTEST_URL = os.getenv("SHADOWTEST_URL", "https://shadowtest.akiel.dev/v2/test")
+SHADOWTEST_SERVERS = [
+    url.strip() for url in os.getenv("SHADOWTEST_URL", "https://shadowtest.akiel.dev/v2/test").split(",")
+]
 
 ALLOWED_HOSTS = [
     "localhost",


### PR DESCRIPTION
SHADOWTEST_URL can now be a comma separated list of shadowtest servers that will be used round-robin style.