### PR TITLE
Revert huey dashboard/stats changes

### DIFF
--- a/proxylist/apps.py
+++ b/proxylist/apps.py
@@ -4,8 +4,3 @@ from django.apps import AppConfig
 class ProxylistConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "proxylist"
-
-    def ready(self):
-        # Register tasks in the web process so the huey stats dashboard
-        # can list them; only run_huey autodiscovers the tasks module.
-        from . import tasks  # noqa: F401

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ gevent==26.5.0
 gunicorn==26.0.0
 huey==3.2.1
 humanfriendly==10.0
-peewee==4.2.1
 prometheus-client==0.25.0
 prompt-toolkit==3.0.52
 psycopg2-binary==2.9.12

--- a/shadowmere/settings.py
+++ b/shadowmere/settings.py
@@ -67,8 +67,7 @@ INSTALLED_APPS = [
     "huey.contrib.djhuey",
     "rest_framework",
     "django_filters",
-    "huey.contrib.djhuey.stats",
-    ]
+]
 
 MIDDLEWARE = [
     "django_prometheus.middleware.PrometheusBeforeMiddleware",


### PR DESCRIPTION
## Summary
- Reverts #830 (Add huey stats to admin) and #831 (Fix huey dashboard)
- Suspected of breaking huey task scheduling: `huey.contrib.djhuey.stats`'s `ready()` hook opens a peewee DB connection and attaches execute signal hooks to the shared HUEY instance in every process (web + all consumer workers), and `proxylist/apps.py` now also imports `tasks.py` (with its periodic task registrations) in the web process, not just the consumer.
- Leaves the routine huey 3.1.1 → 3.2.1 dependency bump in place (unrelated dependabot PR).

## Changes
- `shadowmere/settings.py`: remove `huey.contrib.djhuey.stats` from `INSTALLED_APPS`
- `requirements.txt`: remove `peewee` dependency
- `proxylist/apps.py`: remove the `ready()` override that imports `tasks`

## Test plan
- [ ] Confirm huey consumer starts and periodic/scheduled tasks run again in staging
- [ ] Confirm web process boots without errors